### PR TITLE
fix: update release workflow to build and commit binary after release…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,30 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Run release-please
+        uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+        id: release
+        with:
+          release-type: go
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.23
-
-      # Build and commit the binary before release-please
-      - name: Build and Commit Binary
+      - name: Build and Commit Binary, Push to origin
         run: |
           CGO_ENABLED=0 go build -ldflags="-w -s" -v -o app ./cmd/run
           mkdir -p dist
@@ -33,17 +46,5 @@ jobs:
           git add dist/app
           git status
           git commit -m "Build and update binary" || echo "No changes to commit"
-          # No need to push here, release-please will read the commit
+          git push origin HEAD
 
-      - name: Run release-please
-        uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
-        id: release
-        with:
-          release-type: go
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # If a new release was created, push the changes including the binary commit
-      # The push will happen after release-please creates the tag/release PR
-      - name: Push changes after release-please (if release created)
-        if: ${{ steps.release.outputs.release_created }}
-        run: git push origin HEAD


### PR DESCRIPTION
This pull request refactors the `.github/workflows/release.yml` file to streamline the release process by restructuring the workflow jobs and improving the handling of releases. The key changes include separating the release and deployment steps into distinct jobs, introducing conditional execution for deployment, and removing redundant steps.

### Workflow restructuring and improvements:

* **Separation of jobs**: The workflow now includes a `release-please` job for managing releases and a `deploy` job for building and pushing binaries. The `deploy` job is configured to run only if a release is successfully created (`if: ${{ needs.release-please.outputs.release_created }}`). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R15-R38) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-L49)

* **Removal of redundant steps**: The steps for pushing changes after release-please and running release-please have been removed from the `release-please` job, as they are now handled more effectively within the new structure.

* **Outputs for conditional execution**: The `release-please` job now defines an output (`release_created`) to signal whether a release was created, enabling the `deploy` job to conditionally execute based on this output.